### PR TITLE
Fix reading schema elemnts while transforming xml to object

### DIFF
--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -745,8 +745,8 @@ WSDL.prototype.xmlToObject = function(xml) {
 					if(!refs[id]) refs[id] = {hrefs:[],obj:null};
 				}
 
-        if (topSchema && topSchema[name+'[]']) name = name + '[]';
-        stack.push({name: originalName, object: obj, schema: topSchema && topSchema[name], id:attrs.id});
+        if (topSchema && topSchema['$'+name+'[]']) name = name + '[]';
+        stack.push({name: originalName, object: obj, schema: topSchema && topSchema['$'+name], id:attrs.id});
     })
 
     //p.on('endElement', function(nsName) {
@@ -760,7 +760,7 @@ WSDL.prototype.xmlToObject = function(xml) {
             topSchema = top.schema,
             name = splitNSName(nsName).name;
 
-        if (topSchema && topSchema[name+'[]'] && typeof topSchema[name+'[]']!=='string') {
+        if (topSchema && topSchema['$'+name+'[]'] && typeof topSchema['$'+name+'[]']!=='string') {
             if (!topObject[name]) topObject[name] = [];
             topObject[name].push(obj);
         }


### PR DESCRIPTION
Hello,

I encountered problem in wsdl.js xmlToObject. When I recieved SOAP message containing tag <description> inside complex type library crashed.
I think it was caused by reading schema from ComplexTypeElement which contains function description. Instead argument $description whould be read. I'm not sure if I'm right, but this modification fixed my problems.